### PR TITLE
Added to the AJD V2 README Troubleshooting section

### DIFF
--- a/code/v2/README.md
+++ b/code/v2/README.md
@@ -170,7 +170,7 @@ add `enhance-element` class to any elements you want to enhacne when they come i
 
 
 ### Make in page navigation highlight only one section at a time
-In order to do this all you have to do is look for the class `ajd_navigation` in the HTML and add a class to that same div called `singular-highlighting`
+In order to do this all you have to do is look for the class `ajd_navigation` in the HTML and add a class to that same div called `singular-highlighting`.
 
 
 ### Adjusting the scroll to offset when using the in page navigation
@@ -258,3 +258,6 @@ Solution: In your endscripts add
         html { scroll-behavior: auto !important;}
     </style>
 `
+
+Issue: In page navigation links are not highlighting when the corresponding section is in view.
+Solution: Ensure each section has the "ajd_section" class on it.

--- a/code/v2/README.md
+++ b/code/v2/README.md
@@ -252,7 +252,7 @@ Ideally, AJD sections should use Padding to offset where the sticky nav will sto
 
 
 ## Troubleshooting
-Issue: When using the in page navigation links the scroll seems to be really slow and then fast or acts like it is getting stuck.
+Issue: When using the in page navigation links the scroll seems to be really slow and then fast or acts like it is getting stuck.\
 Solution: In your endscripts add
 `    <style>
         html { scroll-behavior: auto !important;}

--- a/code/v2/README.md
+++ b/code/v2/README.md
@@ -259,5 +259,5 @@ Solution: In your endscripts add
     </style>
 `
 
-Issue: In page navigation links are not highlighting when the corresponding section is in view.
+Issue: In page navigation links are not highlighting when the corresponding section is in view.\
 Solution: Ensure each section has the "ajd_section" class on it.


### PR DESCRIPTION
- Added an item to the troubleshooting section about troubleshooting In Page Navigation links not highlighting when the corresponding section is in view - I picked up a ticket about this and couldn't find anything in the documentation so hoping this might help anyone else in that situation
- Updated formatting in the troubleshooting section so Issue and Solution are on separate lines